### PR TITLE
Fixes README.md method spelling error: dislplayMessageComposer -> displayMessageComposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ private void logout(){
 
 ## How does the in-app messenger work?
 
-Intercom allows you to send messages to your users while also enabling your users send messages to you. If you have a dedicated button in your app that you wish to hook the new message composer up to, you can control Intercom's messaging UI via the `Intercom.client().dislplayMessageComposer();` and `Intercom.client().displayConversationList();` methods. More information on messaging with Intercom for Android can be found [here](http://docs.intercom.io/Install-on-your-mobile-product/configuring-intercom-for-android#messaging).
+Intercom allows you to send messages to your users while also enabling your users send messages to you. If you have a dedicated button in your app that you wish to hook the new message composer up to, you can control Intercom's messaging UI via the `Intercom.client().displayMessageComposer();` and `Intercom.client().displayConversationList();` methods. More information on messaging with Intercom for Android can be found [here](http://docs.intercom.io/Install-on-your-mobile-product/configuring-intercom-for-android#messaging).
 
 ## What about events, push notifications, company and user data?
 


### PR DESCRIPTION
Fixes a small spelling error in the `README.md` with `Intercom.client().dislplayMessageComposer();`:

<img width="821" alt="screen shot 2015-10-26 at 10 24 24" src="https://cloud.githubusercontent.com/assets/5881537/10834875/707bab42-7e9d-11e5-8660-2376501fbfaf.png">
