### PR TITLE
Include repository block into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 ## Install
 
-Add the following dependency to your `build.gradle` file:
+In your app's `build.gradle` file add the following block to your repositories block:
+
+```
+repositories {
+  maven {
+    url 'https://dl.bintray.com/intercom/intercom-maven'
+  }
+}
+```
+
+Then add the following dependency to your `build.gradle` file:
 
 ```gradle
 compile 'io.intercom.android:intercom-sdk:3.+'


### PR DESCRIPTION
The `repository` block was missing in the readme.

I simply updated the instruction to reflect the instructions from the official Intercom docs:
https://docs.intercom.com/install-on-your-product-or-site/quick-install/install-intercom-on-your-android-app
