### PR TITLE
Fixing README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,10 @@ We include the [INTERNET](http://developer.android.com/reference/android/Manifes
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
-You will need to include [READ\_EXTERNAL\_STORAGE](http://developer.android.com/reference/android/Manifest.permission.html#READ_EXTERNAL_STORAGE) and [MANAGE_DOCUMENTS](http://developer.android.com/reference/android/Manifest.permission.html#MANAGE_DOCUMENTS) permissions if you have enabled attachments:
+You will need to include the [READ\_EXTERNAL\_STORAGE](http://developer.android.com/reference/android/Manifest.permission.html#READ_EXTERNAL_STORAGE) permission if you have enabled attachments:
 
 ```xml
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-<uses-permission android:name="android.permission.MANAGE_DOCUMENTS"/>
 ```
 
 You can also include [VIBRATE](http://developer.android.com/reference/android/Manifest.permission.html#VIBRATE) to enable vibration in push notifications:


### PR DESCRIPTION
Removing the statement about `android.permission.MANAGE_DOCUMENTS` from permissions as it's a system-level permission not granted to third party apps.