### PR TITLE
Bump Intercom SDK to 14.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 14.2.0
+###### Release Date: 03-04-2023
+### Help Center Enhancements to Support Multilevel Collections
+
+* Help Center home screen and collections screen have been redesigned to support navigating through collections and nested collections up to 3 level deep
+* The Intercom.client.fetchCollection API response body now includes a list of `collections` within the collection response body. `sections` will be deprecated in the next major release.
+
+### 🐛 Bug Fixes
+* Fixed an issue that caused a crash when opening the Help Centre
+* Fixed a crash with displaying full chat notifications
+* Fixed the issue where it reloads the app after viewing in-app notifications
+
 ## 14.1.0
 ###### Release Date: 13-03-2023
 ### Enhancements: Attach Files to Tickets

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:14.1.0'
+    implementation 'io.intercom.android:intercom-sdk:14.2.0'
     implementation 'com.google.firebase:firebase-messaging:20.+'
 }
 ```
@@ -53,7 +53,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:14.1.0'
+    implementation 'io.intercom.android:intercom-sdk-base:14.2.0'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    implementation("io.intercom.android:intercom-sdk:14.1.0")
+    implementation("io.intercom.android:intercom-sdk:14.2.0")
     implementation("com.google.firebase:firebase-messaging:23.1.0")
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
Bump Intercom SDK to 14.2.0

v14.2.0 is now live on maven https://repo.maven.apache.org/maven2/io/intercom/android/intercom-sdk-base/