### PR TITLE
Fix access the API:LayoutInflater which needs to have proper configuration from a non-UI Context

### DIFF
--- a/sample/app/src/main/java/com/intercom/sample/MainApplication.kt
+++ b/sample/app/src/main/java/com/intercom/sample/MainApplication.kt
@@ -6,6 +6,8 @@ import io.intercom.android.sdk.Intercom
 class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // FIXME: Causes IllegalAccessException: Tried to access the API:LayoutInflater which needs to have proper configuration from a non-UI Context
         Intercom.initialize(this, "", "")
     }
 }


### PR DESCRIPTION
Default recommended way of Intercom initialization causes `IncorrectContextUseViolation` error in [StrictMode](https://developer.android.com/reference/android/os/StrictMode):
```
Tried to access the API:LayoutInflater which needs to have proper configuration from a non-UI Context:Application@2128f8f The API:LayoutInflater needs a proper configuration. Use UI contexts such as an activity or a context created via createWindowContext(Display, int, Bundle) or  createConfigurationContext(Configuration) with a proper configuration.
java.lang.IllegalAccessException: Tried to access the API:LayoutInflater which needs to have proper configuration from a non-UI Context:Application@2128f8f
    at android.os.StrictMode.assertConfigurationContext(StrictMode.java:2296)
    at android.view.LayoutInflater.<init>(LayoutInflater.java:260)
    at com.android.internal.policy.PhoneLayoutInflater.<init>(PhoneLayoutInflater.java:44)
    at android.app.SystemServiceRegistry$33.createService(SystemServiceRegistry.java:534)
    at android.app.SystemServiceRegistry$33.createService(SystemServiceRegistry.java:531)
    at android.app.SystemServiceRegistry$CachedServiceFetcher.getService(SystemServiceRegistry.java:1866)
    at android.app.SystemServiceRegistry.getSystemService(SystemServiceRegistry.java:1527)
    at android.app.ContextImpl.getSystemService(ContextImpl.java:2075)
    at android.content.ContextWrapper.getSystemService(ContextWrapper.java:869)
    at android.view.LayoutInflater.from(LayoutInflater.java:288)
    at io.intercom.android.sdk.overlay.OverlayPresenter.<init>(OverlayPresenter.java:83)
    at io.intercom.android.sdk.Injector.getOverlayPresenter(Injector.java:279)
    at io.intercom.android.sdk.Injector.getResetManager(Injector.java:333)
    at io.intercom.android.sdk.Injector.getLifecycleTracker(Injector.java:311)
    at io.intercom.android.sdk.Injector.initWithAppCredentials(Injector.java:135)
    at io.intercom.android.sdk.Intercom$Companion.create(Intercom.kt:1092)
    at io.intercom.android.sdk.Intercom$Companion.initialize(Intercom.kt:1005)
    at Application.onCreate(App.kt:109)
    at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1212)
    at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7103)
    at android.app.ActivityThread.access$1600(ActivityThread.java:271)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2134)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loopOnce(Looper.java:210)
    at android.os.Looper.loop(Looper.java:299)
    at android.app.ActivityThread.main(ActivityThread.java:8319)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:556)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1038)
```

Please, fix it.