### PR TITLE
Release 15.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15.2.1
+###### Release Date: 07-09-2023
+- Bumped Jetpack Compose version to 1.5.
+- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the previous version of Intercom.
+
 ## 15.2.0
 ###### Release Date: 30-08-2023
 ### 📱 New Feature : Tickets Space in Messenger

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:15.2.0'
+    implementation 'io.intercom.android:intercom-sdk:15.2.1'
     implementation 'com.google.firebase:firebase-messaging:20.+'
 }
 ```
@@ -53,7 +53,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:15.2.0'
+    implementation 'io.intercom.android:intercom-sdk-base:15.2.1'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.intercom.sample"
@@ -36,7 +36,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.2.0"
+        kotlinCompilerExtensionVersion "1.4.8"
     }
     packagingOptions {
         resources {
@@ -48,23 +48,28 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui:$jetpackCompose"
-    implementation "androidx.compose.material:material:$composeMaterial"
-    implementation "androidx.compose.ui:ui-tooling-preview:$jetpackCompose"
+
+    def composeBom = platform('androidx.compose:compose-bom:2023.08.00')
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation("androidx.navigation:navigation-compose:2.7.1")
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.1'
-    implementation("androidx.navigation:navigation-compose:2.5.3")
 
     implementation "com.google.accompanist:accompanist-flowlayout:0.27.0"
 
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    implementation("io.intercom.android:intercom-sdk:15.2.0")
+    implementation("io.intercom.android:intercom-sdk:15.2.1")
     implementation("com.google.firebase:firebase-messaging:23.2.0")
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$jetpackCompose"
-    debugImplementation "androidx.compose.ui:ui-tooling:$jetpackCompose"
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,8 @@
-buildscript {
-    ext {
-        jetpackCompose = '1.3.3'
-        composeMaterial = '1.3.1'
-    }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.3.0' apply false
     id 'com.android.library' version '7.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
- Bumped Jetpack Compose version to 1.5.
- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the previous version of Intercom.