### PR TITLE
Release 15.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 15.2.2
+###### Release Date: 22-09-2023
+- Fixed crash due to concurrent modification exception.
+- Fixed issue with device token removal after user identity reset.
+- Fixed crash related to locale settings on older OS versions.
+- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the previous version of Intercom.
+
 ## 15.2.1
 ###### Release Date: 07-09-2023
 - Bumped Jetpack Compose version to 1.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed crash due to concurrent modification exception.
 - Fixed issue with device token removal after user identity reset.
 - Fixed crash related to locale settings on older OS versions.
-- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the previous version of Intercom.
+- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the Intercom version 15.2.0.
 
 ## 15.2.1
 ###### Release Date: 07-09-2023

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:15.2.1'
+    implementation 'io.intercom.android:intercom-sdk:15.2.2'
     implementation 'com.google.firebase:firebase-messaging:20.+'
 }
 ```
@@ -53,7 +53,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:15.2.1'
+    implementation 'io.intercom.android:intercom-sdk-base:15.2.2'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    implementation("io.intercom.android:intercom-sdk:15.2.1")
+    implementation("io.intercom.android:intercom-sdk:15.2.2")
     implementation("com.google.firebase:firebase-messaging:23.2.0")
 
     testImplementation 'junit:junit:4.13.2'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
+    id 'com.android.application' version '8.1.1' apply false
+    id 'com.android.library' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
 }
 

--- a/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 16 15:00:53 GMT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Release 15.2.2

* Fixed crash due to concurrent modification exception.
* Fixed issue with device token removal after user identity reset.
* Fixed crash related to locale settings on older OS versions.
* This version requires compileSdkVersion to be at least 34. If you are not ready to use API level 34, please stay on the Intercom version 15.2.0.