### PR TITLE
Release 15.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15.2.3
+###### Release Date: 29-09-2023
+- Fixed date and time picker issue.
+- This version requires `compileSdkVersion` to be at least **34**. If you are not ready to use API level 34, please stay on the Intercom version 15.2.0.
+
 ## 15.2.2
 ###### Release Date: 22-09-2023
 - Fixed crash due to concurrent modification exception.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:15.2.2'
+    implementation 'io.intercom.android:intercom-sdk:15.2.3'
     implementation 'com.google.firebase:firebase-messaging:20.+'
 }
 ```
@@ -53,7 +53,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:15.2.2'
+    implementation 'io.intercom.android:intercom-sdk-base:15.2.3'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    implementation("io.intercom.android:intercom-sdk:15.2.2")
+    implementation("io.intercom.android:intercom-sdk:15.2.3")
     implementation("com.google.firebase:firebase-messaging:23.2.0")
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
### Release 15.2.3
* Fixed date and time picker issue.
* This version requires compileSdkVersion to be at least 34. If you are not ready to use API level 34, please stay on the Intercom version 15.2.0.