### PR TITLE
Release 15.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 15.6.3
+###### Release Date: 21-02-2024
+- Added support for custom ticket states external labelling
+- It is now possible to configure whether users are able to start a new conversation when they tap the 😔 reaction on an Article
+
+### 🐛 Bug Fixes
+- Fixed NoSuchMethodError crash caused by Jetpack Compose 1.6 compatibility issue
+- Fixed NoSuchFieldError crash occurring on API < 24
+
 ## 15.6.2
 ###### Release Date: 2-02-2024
 - Bumped Jetpack Compose version to 1.6

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:15.6.2'
+    implementation 'io.intercom.android:intercom-sdk:15.6.3'
     implementation 'com.google.firebase:firebase-messaging:20.+'
 }
 ```
@@ -53,7 +53,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:15.6.2'
+    implementation 'io.intercom.android:intercom-sdk-base:15.6.3'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    implementation("io.intercom.android:intercom-sdk:15.6.2")
+    implementation("io.intercom.android:intercom-sdk:15.6.3")
     implementation("com.google.firebase:firebase-messaging:23.1.0")
 }
 


### PR DESCRIPTION
## 15.6.3
###### Release Date: 21-02-2024
- Added support for custom ticket states external labelling
- It is now possible to configure whether users are able to start a new conversation when they tap the 😔 reaction on an Article

### 🐛 Bug Fixes
- Fixed NoSuchMethodError crash caused by Jetpack Compose 1.6 compatibility issue
- Fixed NoSuchFieldError crash occurring on API < 24