### PR TITLE
Release 15.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## 15.15.2
+###### Release Date: 04-04-2025
+
+### 🐛 Bug Fixes
+* Various bug fixes and performance improvements
+* This release does not enforce apps to target API level 35
+* The minimum Kotlin version needed to use this version of Intercom SDK is now 1.8.22
+
+### Dependency updates
+* `androidx.navigation:navigation-compose` to `2.8.9`
+* `androidx.compose:compose-bom` to `2025.03.01`
+* `io.sentry:sentry-bom` to `8.5.0`
+* `com.google.firebase:firebase-messaging` to `24.1.1`
 
 ## 15.15.0
 ###### Release Date: 11-03-2025

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:15.15.0'
+    implementation 'io.intercom.android:intercom-sdk:15.15.2'
     implementation 'com.google.firebase:firebase-messaging:24.1.+'
 }
 ```
@@ -49,7 +49,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:15.15.0'
+    implementation 'io.intercom.android:intercom-sdk-base:15.15.2'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -65,6 +65,6 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.3")
 
-    implementation("io.intercom.android:intercom-sdk:15.15.0")
+    implementation("io.intercom.android:intercom-sdk:15.15.2")
     implementation("com.google.firebase:firebase-messaging:24.1.0")
 }


### PR DESCRIPTION
## 15.15.2
###### Release Date: 04-04-2025

### 🐛 Bug Fixes
* Various bug fixes and performance improvements
* This release does not enforce apps to target API level 35
* The minimum Kotlin version needed to use this version of Intercom SDK is now 1.8.22

### Dependency updates
* `androidx.navigation:navigation-compose` to `2.8.9`
* `androidx.compose:compose-bom` to `2025.03.01`
* `io.sentry:sentry-bom` to `8.5.0`
* `com.google.firebase:firebase-messaging` to `24.1.1`