### PR TITLE
Release 16.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 16.1.0
+###### Release Date: 20-05-2025
+
+### 🚀 Enhancements
+* Added new API `changeWorkspace`. Use this to change the workspace that the SDK is connected to.
+
+### 👉 Dependency updates
+* Sentry: Updated to 8.12.0
+* Lifecycle Components: Updated to 2.9.0
+* Compose Navigation: Updated to 2.9.0
+
 ## 16.0.0
 ###### Release Date: 09-05-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Lifecycle Components: Updated to 2.9.0
 * Compose Navigation: Updated to 2.9.0
 
+### 👉 Note
+* `registerForLaterInitialisation` and `unregisterForLateInitialisation` are now deprecated. Use `initialize()` instead. SDK will not communicate with Intercom until a user registration is made.
+
 ## 16.0.0
 ###### Release Date: 09-05-2025
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are 2 options for installing Intercom on your Android app.
 Add the following dependency to your app's `build.gradle` file:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk:16.0.0'
+    implementation 'io.intercom.android:intercom-sdk:16.1.0'
     implementation 'com.google.firebase:firebase-messaging:24.1.+'
 }
 ```
@@ -49,7 +49,7 @@ dependencies {
 If you'd rather not have push notifications in your app, you can use this dependency:
 ```groovy
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:16.0.0'
+    implementation 'io.intercom.android:intercom-sdk-base:16.1.0'
 }
 ```
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -65,6 +65,6 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.3")
 
-    implementation("io.intercom.android:intercom-sdk:16.0.0")
+    implementation("io.intercom.android:intercom-sdk:16.1.0")
     implementation("com.google.firebase:firebase-messaging:24.1.0")
 }


### PR DESCRIPTION
### 🚀 Enhancements
- Added new API `changeWorkspace`. Use this to change the workspace that the SDK is connected to.

### 👉 Dependency updates
- Sentry: Updated to 8.12.0
- Lifecycle Components: Updated to 2.9.0
- Compose Navigation: Updated to 2.9.0

### 👉 Note
* `registerForLaterInitialisation` and `unregisterForLateInitialisation` are now deprecated. Use `initialize()` instead. SDK will not communicate with Intercom until a user registration is made.